### PR TITLE
Downgrade to Node 18.18.2 because of Amplify limitations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 20.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 18.x
       - name: Install dependencies
         run: npm ci
       - name: Run ESLint

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=20.8.1"
+    "node": ">=18.18.2"
   },
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
With [this issue](https://github.com/aws-amplify/amplify-hosting/issues/3773), Next apps on Amplify are getting restricted while Amplify tries to support Node 18. At least things are working.